### PR TITLE
質問者が自分の投稿した質問を編集できるようにする

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -27,6 +27,11 @@ class QuestionsController < ApplicationController
   end
 
   def update
+    if @question.update(question_params)
+      redirect_to @question, notice: 'Question was successfully updated.'
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/views/questions/edit.html.haml
+++ b/app/views/questions/edit.html.haml
@@ -1,0 +1,7 @@
+%h1 Editing question
+
+= render 'form'
+
+= link_to 'Show', @question
+\|
+= link_to 'Back', questions_path

--- a/app/views/questions/index.html.haml
+++ b/app/views/questions/index.html.haml
@@ -16,7 +16,9 @@
         %td= question.content
         %td= question.state
         %td= link_to 'Show', question
-        %td= link_to 'Edit', edit_question_path(question)
+        - if question.user == current_user
+        - binding.pry
+          %td= link_to 'Edit', edit_question_path(question)
 %br
 
 = link_to 'New question', new_question_path

--- a/app/views/questions/index.html.haml
+++ b/app/views/questions/index.html.haml
@@ -17,7 +17,6 @@
         %td= question.state
         %td= link_to 'Show', question
         - if question.user == current_user
-        - binding.pry
           %td= link_to 'Edit', edit_question_path(question)
 %br
 

--- a/spec/controllers/questions_controller_spec.rb
+++ b/spec/controllers/questions_controller_spec.rb
@@ -68,4 +68,47 @@ RSpec.describe QuestionsController, type: :controller do
       it { is_expected.to render_template :new }
     end
   end
+
+  describe '#edit' do
+    subject { get :edit, params: { id: question_id } }
+
+    let(:question) { create :question }
+
+    context 'パラメータが有効な時' do
+      let(:question_id) { question.id }
+
+      it { is_expected.to have_http_status(:ok) }
+    end
+
+    context 'パラメータが無効な時' do
+      let(:question_id) { 'aaa' }
+
+      it { expect { subject }.to raise_error ActiveRecord::RecordNotFound }
+    end
+  end
+
+  describe '#update' do
+    subject { put :update, params: { id: question.id, question: question_params } }
+
+    let(:question) { create :question }
+    let(:question_params) { attributes_for :question, subject: new_subject }
+
+    context 'パラメータが有効な時' do
+      let(:new_subject) { "new subject" }
+
+      it do
+        expect { subject }.to change { question.reload.subject }.to(new_subject)
+        is_expected.to redirect_to question
+      end
+    end
+
+    context 'パラメータが無効な時' do
+      let(:new_subject) { "" }
+
+      it do
+        expect { subject }.to_not change { question.reload.subject }
+        is_expected.to render_template :edit
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 目的
質問したユーザーが自分の投稿した質問を編集できるようにする

## 内容
- questions_controllernに#updateを追加
- editテンプレートの追加
- #edit, #updateのテストをquestions_controller_specに追加

## めも
- ログインしているユーザーかどうかの判定
は、別PRで今後作成します