### PR TITLE
タグで検索できるようにする

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,5 +1,5 @@
 class AnswersController < ApplicationController
-  before_action :set_question, only: :create
+  before_action :set_question, only: [:new, :create]
   def new
     @answer = Answer.new
   end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,17 +1,10 @@
 class TagsController < ApplicationController
   before_action :set_question_from_id, only: [:edit, :update]
 
-<<<<<<< HEAD
-=======
-  def new
-    @tag_form = TagForm.new
-  end
-
   def show
     @tag = Tag.find_by(id: params[:id])
   end
 
->>>>>>> Add show action and template
   def edit
     @tag_form = TagForm.new(question: @question)
   end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,6 +1,17 @@
 class TagsController < ApplicationController
   before_action :set_question_from_id, only: [:edit, :update]
 
+<<<<<<< HEAD
+=======
+  def new
+    @tag_form = TagForm.new
+  end
+
+  def show
+    @tag = Tag.find(10)
+  end
+
+>>>>>>> Add show action and template
   def edit
     @tag_form = TagForm.new(question: @question)
   end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -8,7 +8,7 @@ class TagsController < ApplicationController
   end
 
   def show
-    @tag = Tag.find(10)
+    @tag = Tag.find_by(id: params[:id])
   end
 
 >>>>>>> Add show action and template

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -2,7 +2,7 @@ class TagsController < ApplicationController
   before_action :set_question_from_id, only: [:edit, :update]
 
   def show
-    @tag = Tag.find_by(id: params[:id])
+    @tag = Tag.find(params[:id])
   end
 
   def edit

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -11,8 +11,4 @@ class Question < ApplicationRecord
 
   scope :search_with_keyword, -> (keyword) { where("subject like :keyword OR content like :keyword",
                                   {keyword: "%#{sanitize_sql_like(keyword)}%"} ) }
-
-  def show_tags
-    tags.map(&:name).join(" ")
-  end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -11,4 +11,8 @@ class Question < ApplicationRecord
 
   scope :search_with_keyword, -> (keyword) { where("subject like :keyword OR content like :keyword",
                                   {keyword: "%#{sanitize_sql_like(keyword)}%"} ) }
+
+  def show_tags
+    tags.map(&:name).join(" ")
+  end
 end

--- a/app/views/answers/new.html.haml
+++ b/app/views/answers/new.html.haml
@@ -2,4 +2,4 @@
 
 = render 'form'
 
-= link_to 'Back', root_path
+= link_to '戻る', @question

--- a/app/views/questions/edit.html.haml
+++ b/app/views/questions/edit.html.haml
@@ -2,6 +2,4 @@
 
 = render 'form'
 
-= link_to 'Show', @question
-\|
-= link_to 'Back', questions_path
+= link_to '戻る', @question

--- a/app/views/questions/index.html.haml
+++ b/app/views/questions/index.html.haml
@@ -20,7 +20,9 @@
           %td= link_to question.subject, question
           %td= question.content
           %td= question.state
-          %td= question.show_tags
+          %td
+            - question.tags.each do |tag|
+              %span= link_to tag.name, tag
   %br
 
 = link_to 'New question', new_question_path

--- a/app/views/questions/show.html.haml
+++ b/app/views/questions/show.html.haml
@@ -24,5 +24,7 @@
     = link_to 'タグを追加する', question_tags_edit_path
 
 %p
+  - if @question.user == current_user
+    = link_to '編集する', edit_question_path(@question)
   = link_to '回答する', new_question_answer_path(@question)
-  = link_to 'Back', questions_path
+  = link_to '戻る', questions_path

--- a/app/views/tags/show.html.haml
+++ b/app/views/tags/show.html.haml
@@ -18,7 +18,10 @@
           %td= link_to question.subject, question
           %td= question.content
           %td= question.state
-          %td= question.show_tags
+          %td
+            - question.tags.each do |tag|
+              %span= link_to tag.name, tag
   %br
 
+= link_to '戻る', questions_path
 = link_to 'New question', new_question_path

--- a/app/views/tags/show.html.haml
+++ b/app/views/tags/show.html.haml
@@ -1,11 +1,9 @@
-%h1 Listing questions
+%h1 tag [#{@tag.name}]
 
-= render 'search_form'
-
-- if @questions.empty?
+- if @tag.questions.nil?
   %p= "--該当する質問がありません--"
 - else
-  %p= "--#{@questions.count}件の質問があります--"
+  %p= "--#{@tag.questions.count}件の質問があります--"
   %table
     %thead
       %tr
@@ -15,7 +13,7 @@
         %th Tags
 
     %tbody
-      - @questions.each do |question|
+      - @tag.questions.each do |question|
         %tr
           %td= link_to question.subject, question
           %td= question.content

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get 'logout', to: 'sessions#destroy'
   get 'questions/:id/tags/edit', to: 'tags#edit', as: :question_tags_edit
   post 'questions/:id/tags/edit', to: 'tags#update'
+  get 'tags/:id', to: 'tags#show', as: :tag
 
   resources :users, only: [:index, :new, :show, :create]
 

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -1,6 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe TagsController, type: :controller do
+  describe '#show' do
+    subject { get :show, params: { id: tag_id } }
+
+    context 'パラメータが有効なとき' do
+      let(:tag) { create :tag }
+      let(:tag_id) { tag.id }
+
+      it do
+        is_expected.to have_http_status(:ok)
+        expect(assigns(:tag)).to eq tag
+      end
+    end
+
+    context 'パラメータが無効なとき' do
+      let(:tag_id) { 'aaa' }
+
+      it { expect { subject }.to raise_error ActiveRecord::RecordNotFound }
+    end
+  end
 
   describe '#edit' do
     subject { get :edit, params: { id: question_id } }


### PR DESCRIPTION
## 目的
タグで検索できるようにする（問い合わせ一覧ページでタグをクリックすると、タグがついている質問の一覧が閲覧できる）

## 内容
- 問い合わせ一覧ページで、問い合わせごとに紐づいているタグを表示させる
- 表示させたタグは/tags/:idへのリンクにする
- リンク先ではタグに紐づいている問い合わせの一覧を表示させる

- /tags/:id routing 追加
- tags#showの追加
- show templateの追加
- 細々とリンクテキストを日本語に変更