### PR TITLE
ユーザーがログインしているかどうかでリダイレクトさせるページを決める

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,21 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+  helper_method :logged_in?, :current_user
+  before_action :require_login
+
   include SessionsHelper
+
+  private
+
+    def current_user
+      @current_user ||= User.find_by(id: session[:user_id])
+    end
+
+    def logged_in?
+      current_user.present?
+    end
+
+    def require_login
+      redirect_to root_path unless logged_in?
+    end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :require_login
+  
   def new
   end
 

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,4 +1,12 @@
 class TopController < ApplicationController
+  skip_before_action :require_login
+  before_action :redirect_logged_in_user
+
   def index
   end
+
+  private
+    def redirect_logged_in_user
+      redirect_to questions_path if logged_in?
+    end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_user, only: :show
+  skip_before_action :require_login, only: [:new, :create]
 
   def index
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,9 +2,6 @@ class UsersController < ApplicationController
   before_action :set_user, only: :show
   skip_before_action :require_login, only: [:new, :create]
 
-  def index
-  end
-
   def new
     @user = User.new
   end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -7,12 +7,4 @@ module SessionsHelper
     session.delete(:user_id)
     @current_user = nil
   end
-
-  def current_user
-    @current_user ||= User.find_by(id: session[:user_id])
-  end
-
-  def logged_in?
-    current_user.present?
-  end
 end

--- a/app/views/questions/index.html.haml
+++ b/app/views/questions/index.html.haml
@@ -1,5 +1,7 @@
 %h1 Listing questions
 
+= link_to 'Log Out', logout_path
+
 = render 'search_form'
 
 - if @questions.empty?

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -3,5 +3,3 @@
 = link_to 'Log In', login_path
 \/
 = link_to 'New User', new_user_path
-\/
-= link_to 'Log Out', logout_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   post 'questions/:id/tags/edit', to: 'tags#update'
   get 'tags/:id', to: 'tags#show', as: :tag
 
-  resources :users, only: [:index, :new, :show, :create]
+  resources :users, only: [:new, :show, :create]
 
   resources :questions, except: :destroy do
     resources :answers, only: [:new, :create]

--- a/spec/controllers/answers_controller_spec.rb
+++ b/spec/controllers/answers_controller_spec.rb
@@ -3,9 +3,19 @@ require 'rails_helper'
 RSpec.describe Questions::AnswersController, type: :controller do
   describe "#new" do
     subject { get :new, params: { question_id: question.id } }
-
     let(:question) { create :question }
-    it { is_expected.to have_http_status(:ok) }
+
+    context 'when user is logged_in' do
+      before { session[:user_id] = user.id }
+
+      let(:user) { create :user }
+
+      it { is_expected.to have_http_status(:ok) }
+    end
+
+    context '' do
+      it { is_expected.to redirect_to root_path }
+    end
   end
 
   describe "#create" do
@@ -39,7 +49,7 @@ RSpec.describe Questions::AnswersController, type: :controller do
     context 'ログインしていない時' do
       let(:answer_params) { attributes_for :answer }
 
-      it { is_expected.to render_template :new }
+      it { is_expected.to redirect_to root_path }
     end
   end
 end

--- a/spec/controllers/questions_controller_spec.rb
+++ b/spec/controllers/questions_controller_spec.rb
@@ -4,17 +4,29 @@ RSpec.describe QuestionsController, type: :controller do
   describe '#index' do
     subject { get :index }
 
+    before { session[:user_id] = user.id }
+
+    let(:user) { create :user }
+
     it { is_expected.to have_http_status(:ok) }
   end
 
   describe '#new' do
     subject { get :new }
 
+    before { session[:user_id] = user.id }
+
+    let(:user) { create :user }
+
     it { is_expected.to have_http_status(:ok) }
   end
 
   describe '#show' do
     subject { get :show, params: { id: question_id } }
+
+    before { session[:user_id] = user.id }
+
+    let(:user) { create :user }
 
     context 'パラメータが有効なとき' do
       let(:question) { create :question }
@@ -65,13 +77,16 @@ RSpec.describe QuestionsController, type: :controller do
     context 'ログインしていないとき' do
       let(:question_params) { attributes_for :question }
 
-      it { is_expected.to render_template :new }
+      it { is_expected.to redirect_to root_path }
     end
   end
 
   describe '#edit' do
     subject { get :edit, params: { id: question_id } }
 
+    before { session[:user_id] = user.id }
+
+    let(:user) { create :user }
     let(:question) { create :question }
 
     context 'パラメータが有効な時' do
@@ -90,6 +105,9 @@ RSpec.describe QuestionsController, type: :controller do
   describe '#update' do
     subject { put :update, params: { id: question.id, question: question_params } }
 
+    before { session[:user_id] = user.id }
+
+    let(:user) { create :user }
     let(:question) { create :question }
     let(:question_params) { attributes_for :question, subject: new_subject }
 

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe TagsController, type: :controller do
   describe '#show' do
     subject { get :show, params: { id: tag_id } }
 
+    before { session[:user_id] = user.id }
+
+    let(:user) { create :user }
+
     context 'パラメータが有効なとき' do
       let(:tag) { create :tag }
       let(:tag_id) { tag.id }
@@ -24,6 +28,9 @@ RSpec.describe TagsController, type: :controller do
   describe '#edit' do
     subject { get :edit, params: { id: question_id } }
 
+    before { session[:user_id] = user.id }
+
+    let(:user) { create :user }
     let(:question) { create :question }
 
     context 'パラメータが有効な時' do
@@ -42,6 +49,9 @@ RSpec.describe TagsController, type: :controller do
   describe '#update' do
     subject { put :update, params: { tag_form: tag_params, id: question.id } }
 
+    before { session[:user_id] = user.id }
+
+    let(:user) { create :user }
     let!(:question) { create :question, tags: [tag1, tag2] }
     let(:tag1) { create :tag, name: "tag1" }
     let(:tag2) { create :tag, name: "tag2" }

--- a/spec/controllers/top_controller_spec.rb
+++ b/spec/controllers/top_controller_spec.rb
@@ -1,5 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe TopController, type: :controller do
+  describe '#index' do
+    subject { get :index }
 
+    context 'when user is logged_in' do
+      before { session[:user_id] = user.id }
+
+      let(:user) { create :user }
+
+      it { is_expected.to redirect_to questions_path }
+    end
+
+    context 'when user is not logged_in' do
+      it { is_expected.to have_http_status(:ok) }
+    end
+  end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -11,7 +11,16 @@ RSpec.describe UsersController, type: :controller do
     subject { get :show, params: { id: user.id } }
 
     let(:user) { create :user }
-    it { is_expected.to have_http_status(:ok) }
+
+    context 'when user is logged_in' do
+      before { session[:user_id] = user.id }
+
+      it { is_expected.to have_http_status(:ok) }
+    end
+
+    context 'when user is not logged_in' do
+      it { is_expected.to redirect_to root_path }
+    end
   end
 
   describe '#create' do

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -18,30 +18,4 @@ RSpec.describe SessionsHelper, type: :helper do
 
     it { is_expected.to change { session[:user_id] }.from(user.id).to(nil) }
   end
-  # 
-  # describe '#current_user' do
-  #   subject { helper.current_user }
-  #
-  #   let(:user) { create :user }
-  #
-  #   before { helper.log_in(user) }
-  #
-  #   it { is_expected.to eq user }
-  # end
-  #
-  # describe '#logged_in?' do
-  #   subject { helper.logged_in? }
-  #
-  #   context 'when user is logged_in' do
-  #     let(:user) { create :user }
-  #
-  #     before { helper.log_in(user) }
-  #
-  #     it { is_expected.to be_truthy }
-  #   end
-  #
-  #   context 'when user is not logged_in' do
-  #     it { is_expected.to be_falsey }
-  #   end
-  # end
 end

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -18,30 +18,30 @@ RSpec.describe SessionsHelper, type: :helper do
 
     it { is_expected.to change { session[:user_id] }.from(user.id).to(nil) }
   end
-
-  describe '#current_user' do
-    subject { helper.current_user }
-
-    let(:user) { create :user }
-
-    before { helper.log_in(user) }
-
-    it { is_expected.to eq user }
-  end
-
-  describe '#logged_in?' do
-    subject { helper.logged_in? }
-
-    context 'when user is logged_in' do
-      let(:user) { create :user }
-
-      before { helper.log_in(user) }
-
-      it { is_expected.to be_truthy }
-    end
-
-    context 'when user is not logged_in' do
-      it { is_expected.to be_falsey }
-    end
-  end
+  # 
+  # describe '#current_user' do
+  #   subject { helper.current_user }
+  #
+  #   let(:user) { create :user }
+  #
+  #   before { helper.log_in(user) }
+  #
+  #   it { is_expected.to eq user }
+  # end
+  #
+  # describe '#logged_in?' do
+  #   subject { helper.logged_in? }
+  #
+  #   context 'when user is logged_in' do
+  #     let(:user) { create :user }
+  #
+  #     before { helper.log_in(user) }
+  #
+  #     it { is_expected.to be_truthy }
+  #   end
+  #
+  #   context 'when user is not logged_in' do
+  #     it { is_expected.to be_falsey }
+  #   end
+  # end
 end


### PR DESCRIPTION
## 目的
ユーザーがログインしているかどうかでリダイレクトさせるページを決める

## 内容
ユーザーの動きとしては
- ログインユーザー以外がトップページ以外にアクセスするとトップページにリダイレクトするようにする

->`require_login`メソッドを作って、sessions_controllerと users_controllerの#new, #create以外でbefore_actionで実行する

- ログインユーザーがトップページにアクセスすると/questionsへリダイレクトするようにする

-> `redirect_logged_in_user`メソッドを作ってtop_controllerの#indexでbefore_actionで実行する

- [x] テストの追加

### めも
top#indexが今のroot_pathになっているが、ユーザー的にはログインした後/questionsがルートになるのが自然な気がするのでこの辺も別PRでいい感じにしたい
